### PR TITLE
VTKU-43 : edellinen sijoittelu turhaan muistissa

### DIFF
--- a/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin.java
+++ b/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin.java
@@ -1,7 +1,6 @@
 package fi.vm.sade.sijoittelu.batch.logic.impl.algorithm.presijoitteluprocessor;
 
 import com.google.common.collect.Collections2;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 
@@ -16,11 +15,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 class PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin implements PreSijoitteluProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin.class);
@@ -39,7 +39,8 @@ class PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin implements Pre
             setAlkuperaisetAloituspaikat(hakukohde);
 
             if(sijoitteluajoWrapper.isKKHaku()) {
-                HashMap<String, ValintatapajonoWrapper> oid2Valintatapajono = populateOid2Valintatapajono(hakukohde);
+                Map<String, ValintatapajonoWrapper> oid2Valintatapajono = hakukohde.getValintatapajonot().stream()
+                    .collect(Collectors.toUnmodifiableMap(j -> j.getValintatapajono().getOid(), Function.identity()));
 
                 Queue<ValintatapajonoWrapper> toBeProcessed = Queues.newConcurrentLinkedQueue(hakukohde.getValintatapajonot());
 
@@ -72,14 +73,6 @@ class PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin implements Pre
             Valintatapajono valintatapajono = valintatapajonoWrapper.getValintatapajono();
             valintatapajono.setAlkuperaisetAloituspaikat(valintatapajono.getAloituspaikat());
         });
-    }
-
-    private HashMap<String, ValintatapajonoWrapper> populateOid2Valintatapajono(HakukohdeWrapper hakukohde) {
-        HashMap<String, ValintatapajonoWrapper> oid2Valintatapajono = Maps.newHashMap();
-        hakukohde.getValintatapajonot().forEach(valintatapajonoWrapper ->
-            oid2Valintatapajono.put(valintatapajonoWrapper.getValintatapajono().getOid(), valintatapajonoWrapper)
-        );
-        return oid2Valintatapajono;
     }
 
     private int getJaljellaOlevatAloituspaikat(ValintatapajonoWrapper wrapper) {

--- a/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin.java
+++ b/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin.java
@@ -31,7 +31,6 @@ class PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin implements Pre
             HakemuksenTila.HYVAKSYTTY,
             HakemuksenTila.VARALLA,
             HakemuksenTila.VARASIJALTA_HYVAKSYTTY);
-    private Queue<ValintatapajonoWrapper> toBeProcessed;
 
     @Override
     public void process(SijoitteluajoWrapper sijoitteluajoWrapper) {
@@ -42,7 +41,7 @@ class PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin implements Pre
             if(sijoitteluajoWrapper.isKKHaku()) {
                 populateOid2Valintatapajono(hakukohde);
 
-                toBeProcessed = Queues.newConcurrentLinkedQueue(hakukohde.getValintatapajonot());
+                Queue<ValintatapajonoWrapper> toBeProcessed = Queues.newConcurrentLinkedQueue(hakukohde.getValintatapajonot());
 
                 // Iteroidaan jokaisen jonon ja täyttöjonojen läpi
                 int iterationCount = 0;

--- a/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin.java
+++ b/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin.java
@@ -26,7 +26,7 @@ class PreSijoitteluProcessorJarjesteleAloituspaikatTayttojonoihin implements Pre
     private static final int LIMIT = 1000;
 
     private Map<String, ValintatapajonoWrapper> oid2Valintatapajono;
-    private Set<HakemuksenTila> hyvaksyttavissaTilat = Sets.newHashSet(
+    private static Set<HakemuksenTila> hyvaksyttavissaTilat = Sets.newHashSet(
             null,
             HakemuksenTila.HYVAKSYTTY,
             HakemuksenTila.VARALLA,

--- a/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorKiilaavatHakemuksetVaralleRajatunVarasijataytonJonoissa.java
+++ b/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorKiilaavatHakemuksetVaralleRajatunVarasijataytonJonoissa.java
@@ -16,8 +16,7 @@ import java.util.stream.Collectors;
 
 public class PreSijoitteluProcessorKiilaavatHakemuksetVaralleRajatunVarasijataytonJonoissa implements PreSijoitteluProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(PreSijoitteluProcessorKiilaavatHakemuksetVaralleRajatunVarasijataytonJonoissa.class);
-
-    private final Collection<HakemuksenTila> HYLATTY_TAI_PERUUNTUNUT = Arrays.asList(HakemuksenTila.HYLATTY, HakemuksenTila.PERUUNTUNUT);
+    private static final Collection<HakemuksenTila> HYLATTY_TAI_PERUUNTUNUT = Arrays.asList(HakemuksenTila.HYLATTY, HakemuksenTila.PERUUNTUNUT);
 
     @Override
     public void process(SijoitteluajoWrapper sijoitteluajoWrapper) {

--- a/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorPeruutaAlemmatPeruneetJaHyvaksytyt.java
+++ b/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorPeruutaAlemmatPeruneetJaHyvaksytyt.java
@@ -1,12 +1,12 @@
 package fi.vm.sade.sijoittelu.batch.logic.impl.algorithm.presijoitteluprocessor;
 
-import fi.vm.sade.sijoittelu.domain.TilanKuvaukset;
 import fi.vm.sade.sijoittelu.batch.logic.impl.algorithm.wrappers.HakemusWrapper;
 import fi.vm.sade.sijoittelu.batch.logic.impl.algorithm.wrappers.HenkiloWrapper;
 import fi.vm.sade.sijoittelu.batch.logic.impl.algorithm.wrappers.SijoitteluajoWrapper;
 import fi.vm.sade.sijoittelu.domain.HakemuksenTila;
 import fi.vm.sade.sijoittelu.domain.Hakemus;
 import fi.vm.sade.sijoittelu.domain.IlmoittautumisTila;
+import fi.vm.sade.sijoittelu.domain.TilanKuvaukset;
 import fi.vm.sade.sijoittelu.domain.ValintatuloksenTila;
 import fi.vm.sade.sijoittelu.domain.Valintatulos;
 import org.slf4j.Logger;
@@ -27,8 +27,8 @@ import java.util.function.Consumer;
 public class PreSijoitteluProcessorPeruutaAlemmatPeruneetJaHyvaksytyt implements PreSijoitteluProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(PreSijoitteluProcessorPeruutaAlemmatPeruneetJaHyvaksytyt.class);
 
-    private final List<ValintatuloksenTila> vastaanotot = Arrays.asList(ValintatuloksenTila.EHDOLLISESTI_VASTAANOTTANUT, ValintatuloksenTila.VASTAANOTTANUT_SITOVASTI);
-    private final List<HakemuksenTila> yliajettavat = Arrays.asList(HakemuksenTila.HYVAKSYTTY, HakemuksenTila.VARALLA, HakemuksenTila.VARASIJALTA_HYVAKSYTTY);
+    private static final List<ValintatuloksenTila> vastaanotot = Arrays.asList(ValintatuloksenTila.EHDOLLISESTI_VASTAANOTTANUT, ValintatuloksenTila.VASTAANOTTANUT_SITOVASTI);
+    private static final List<HakemuksenTila> yliajettavat = Arrays.asList(HakemuksenTila.HYVAKSYTTY, HakemuksenTila.VARALLA, HakemuksenTila.VARASIJALTA_HYVAKSYTTY);
 
     @Override
     public void process(SijoitteluajoWrapper sijoitteluajoWrapper) {

--- a/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorPidaPeruuntuneinaSivssnovHakemuksetRajatunVarasijataytonJonoissa.java
+++ b/sijoittelu-algoritmi-batch/src/main/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/presijoitteluprocessor/PreSijoitteluProcessorPidaPeruuntuneinaSivssnovHakemuksetRajatunVarasijataytonJonoissa.java
@@ -12,7 +12,7 @@ import fi.vm.sade.sijoittelu.domain.Valintatapajono;
 import java.util.function.Consumer;
 
 public class PreSijoitteluProcessorPidaPeruuntuneinaSivssnovHakemuksetRajatunVarasijataytonJonoissa implements PreSijoitteluProcessor {
-    private final Consumer<HakemusWrapper> lukitseEdellinenPeruuntunutTila = hakemusWrapper -> {
+    private static final Consumer<HakemusWrapper> lukitseEdellinenPeruuntunutTila = hakemusWrapper -> {
         Hakemus hakemus = hakemusWrapper.getHakemus();
         if (PERUUNTUNUT.equals(hakemus.getEdellinenTila()) && !hakemusWrapper.getHyvaksyPeruuntunut()) {
             hakemus.setTila(HakemuksenTila.PERUUNTUNUT);

--- a/sijoittelu-algoritmi-batch/src/test/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/RajattuVarasijatayttoTest.java
+++ b/sijoittelu-algoritmi-batch/src/test/java/fi/vm/sade/sijoittelu/batch/logic/impl/algorithm/RajattuVarasijatayttoTest.java
@@ -58,6 +58,7 @@ public class RajattuVarasijatayttoTest {
         .withValintatapajono(jono).build();
     private Hakukohde toinenHakukohdeJohonHakemus1Hyvaksytaan = new HakukohdeBuilder("toinenHakukohdeOid")
         .withValintatapajono(new ValintatapajonoBuilder()
+            .withOid("jono2")
             .withAloituspaikat(1)
             .withTasasijasaanto(YLITAYTTO)
             .withPrioriteetti(0)
@@ -69,6 +70,7 @@ public class RajattuVarasijatayttoTest {
             .build()).build();
     private Hakukohde toinenHakukohdeJohonHakemus2Hyvaksytaan = new HakukohdeBuilder("kolmasHakukohdeOid")
             .withValintatapajono(new ValintatapajonoBuilder()
+                    .withOid("jono3")
                     .withAloituspaikat(1)
                     .withTasasijasaanto(YLITAYTTO)
                     .withPrioriteetti(0)


### PR DESCRIPTION
`PreSijoitteluProcessor`- ja `PostSijoitteluProcessor`-instanssit ovat [SijoitteluBusinessService-singletonin kenttinä muistissa](https://github.com/Opetushallitus/sijoittelu/blob/c4bd843297ba7661a66acf8881cf8023d736110c/sijoittelu-service/src/main/java/fi/vm/sade/sijoittelu/laskenta/service/business/SijoitteluBusinessService.java#L104-L105), joten niissä ei kannata olla tilaa.