### PR TITLE
Tuore valintalaskenta ja valintaperusteet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,22 +34,32 @@
     </distributionManagement>
 
 <properties>
-    <cxf.version>3.3.2</cxf.version>
-    <fasterxml.jackson.version>2.9.5</fasterxml.jackson.version>
+    <cxf.version>3.3.7</cxf.version>
+    <fasterxml.jackson.version>2.11.1</fasterxml.jackson.version>
     <flapdoodle.embed.mongo.version>2.2.0</flapdoodle.embed.mongo.version>
     <jackson.version>1.9.13</jackson.version>
-    <slf4j.version>1.7.5</slf4j.version>
-    <spring.version>5.1.5.RELEASE</spring.version>
-    <spring.security.version>4.2.11.RELEASE</spring.security.version>
-    <surefire.plugin.version>2.12</surefire.plugin.version>
+    <slf4j.version>1.7.30</slf4j.version>
+    <spring.version>5.1.16.RELEASE</spring.version>
+    <spring.security.version>4.2.17.RELEASE</spring.security.version>
+    <surefire.plugin.version>2.22.2</surefire.plugin.version>
     <swagger.version>1.5.16</swagger.version>
-    <jetty.version>9.4.15.v20190215</jetty.version>
+    <jetty.version>9.4.30.v20200611</jetty.version>
     <valintalaskenta.version>5.15-SNAPSHOT</valintalaskenta.version>
     <valintaperusteet-api.version>5.15-SNAPSHOT</valintaperusteet-api.version>
 </properties>
 
     <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>fi.vm.sade.sijoittelu</groupId>
+        <artifactId>sijoittelu-algoritmi-domain</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>fi.vm.sade.sijoittelu</groupId>
+        <artifactId>sijoittelu-tulos-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.json4s</groupId>
         <artifactId>json4s-jackson_2.11</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>fi.vm.sade.sijoittelu</groupId>
     <artifactId>sijoittelu</artifactId>
     <packaging>pom</packaging>
-    <version>7.5.0-SNAPSHOT</version>
+    <version>7.6.0-SNAPSHOT</version>
     <name>Sijoittelu</name>
 
     <modules>
@@ -44,8 +44,8 @@
     <surefire.plugin.version>2.12</surefire.plugin.version>
     <swagger.version>1.5.16</swagger.version>
     <jetty.version>9.4.15.v20190215</jetty.version>
-    <valintalaskenta.version>5.6-SNAPSHOT</valintalaskenta.version>
-    <valintaperusteet-api.version>5.6-SNAPSHOT</valintaperusteet-api.version>
+    <valintalaskenta.version>5.15-SNAPSHOT</valintalaskenta.version>
+    <valintaperusteet-api.version>5.15-SNAPSHOT</valintaperusteet-api.version>
 </properties>
 
     <dependencyManagement>
@@ -755,6 +755,37 @@
         <groupId>org.reactivestreams</groupId>
         <artifactId>reactive-streams</artifactId>
         <version>1.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.http4s</groupId>
+        <artifactId>blaze-http_2.11</artifactId>
+        <version>0.12.11</version>
+      </dependency>
+      <!-- +-org.spire-math:jawn-parser_2.11:0.10.4  -->
+      <dependency>
+        <groupId>org.spire-math</groupId>
+        <artifactId>jawn-parser_2.11</artifactId>
+        <version>0.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.json4s</groupId>
+        <artifactId>json4s-core_2.11</artifactId>
+        <version>3.5.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.json4s</groupId>
+        <artifactId>json4s-ast_2.11</artifactId>
+        <version>3.5.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.json4s</groupId>
+        <artifactId>json4s-native_2.11</artifactId>
+        <version>3.5.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scalaz</groupId>
+        <artifactId>scalaz-core_2.11</artifactId>
+        <version>7.2.17</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/sijoittelu-algoritmi-batch/pom.xml
+++ b/sijoittelu-algoritmi-batch/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <artifactId>sijoittelu</artifactId>
         <groupId>fi.vm.sade.sijoittelu</groupId>
-        <version>7.5.0-SNAPSHOT</version>
+        <version>7.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sijoittelu-algoritmi-batch</artifactId>
     <name>Sijoittelu :: Algoritmi :: Batch</name>
     <packaging>jar</packaging>
-    <version>7.5.0-SNAPSHOT</version>
+    <version>7.6.0-SNAPSHOT</version>
 
     <dependencies>
 

--- a/sijoittelu-algoritmi-domain/pom.xml
+++ b/sijoittelu-algoritmi-domain/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <artifactId>sijoittelu</artifactId>
         <groupId>fi.vm.sade.sijoittelu</groupId>
-        <version>7.5.0-SNAPSHOT</version>
+        <version>7.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sijoittelu-algoritmi-domain</artifactId>
     <name>Sijoittelu :: Algoritmi :: Domain</name>
     <packaging>jar</packaging>
-    <version>7.5.0-SNAPSHOT</version>
+    <version>7.6.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/sijoittelu-service/pom.xml
+++ b/sijoittelu-service/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>fi.vm.sade.sijoittelu</groupId>
 		<artifactId>sijoittelu</artifactId>
-		<version>7.5.0-SNAPSHOT</version>
+		<version>7.6.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>sijoittelu-service</artifactId>
 	<name>Sijoittelu :: Service :: API</name>
 	<packaging>jar</packaging>
-	<version>7.5.0-SNAPSHOT</version>
+	<version>7.6.0-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>

--- a/sijoittelu-service/src/main/java/fi/vm/sade/sijoittelu/laskenta/service/business/SijoitteluBusinessService.java
+++ b/sijoittelu-service/src/main/java/fi/vm/sade/sijoittelu/laskenta/service/business/SijoitteluBusinessService.java
@@ -219,6 +219,7 @@ public class SijoitteluBusinessService {
         Consumer<String> handleError = (msg) -> {
             LOG.error(msg);
             stopWatch.stop();
+            LOG.info(stopWatch.toString());
             LOG.info(stopWatch.prettyPrint());
             throw new RuntimeException(msg);
         };

--- a/sijoittelu-service/src/main/resources/spring/context/application-context.xml
+++ b/sijoittelu-service/src/main/resources/spring/context/application-context.xml
@@ -186,6 +186,8 @@
         <constructor-arg type="java.lang.String" value="${valintalaskenta-laskenta-service.mongodb.dbname}" />
         </bean>
 
+        <bean id="laskentaAuditLog" class="fi.vm.sade.valintalaskenta.tulos.logging.LaskentaAuditLogImpl"/>
+
         <bean id="modelMapper" class="fi.vm.sade.valintalaskenta.tulos.mapping.ValintalaskentaModelMapper"/>
 
         <bean id="sijoitteluModelMapper" class="fi.vm.sade.sijoittelu.laskenta.mapping.SijoitteluModelMapper"/>

--- a/sijoittelu-service/src/test/resources/test-sijoittelu-batch-mongo.xml
+++ b/sijoittelu-service/src/test/resources/test-sijoittelu-batch-mongo.xml
@@ -34,6 +34,8 @@
 
     <bean id="sijoitteluModelMapper" class="fi.vm.sade.sijoittelu.laskenta.mapping.SijoitteluModelMapper"/>
 
+    <bean id="laskentaAuditLog" class="fi.vm.sade.valintalaskenta.tulos.logging.LaskentaAuditLogImpl"/>
+
 </beans>
 
 

--- a/sijoittelu-tulos-api/pom.xml
+++ b/sijoittelu-tulos-api/pom.xml
@@ -5,12 +5,12 @@
 	<artifactId>sijoittelu-tulos-api</artifactId>
 	<name>Sijoittelu :: Tulos :: API</name>
 	<packaging>jar</packaging>
-	<version>7.5.0-SNAPSHOT</version>
+	<version>7.6.0-SNAPSHOT</version>
 
 	<parent>
 		<groupId>fi.vm.sade.sijoittelu</groupId>
 		<artifactId>sijoittelu</artifactId>
-		<version>7.5.0-SNAPSHOT</version>
+		<version>7.6.0-SNAPSHOT</version>
 	</parent>
 
 

--- a/sijoittelu-tulos-service/pom.xml
+++ b/sijoittelu-tulos-service/pom.xml
@@ -7,12 +7,12 @@
     <artifactId>sijoittelu-tulos-service</artifactId>
     <packaging>jar</packaging>
     <name>Sijoittelu :: Tulos :: Service</name>
-    <version>7.5.0-SNAPSHOT</version>
+    <version>7.6.0-SNAPSHOT</version>
 
     <parent>
         <groupId>fi.vm.sade.sijoittelu</groupId>
         <artifactId>sijoittelu</artifactId>
-        <version>7.5.0-SNAPSHOT</version>
+        <version>7.6.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Olisiko valinta-tulos-servicessä päivittynyt riippuvuuksia,
joka aiheutti Scala-kirjastoissakin ristiriitoja.

Laskentapuolella on jokin uusi auditlog-asia näemmä tullut
myös.

Nähtäväksi jää, korjaisiko tämä tällaisen ongelman sijoitteluajon alun tietojen lataamisessa:

Exception in thread "Thread-27" java.lang.RuntimeException: Valintatietojen haku epäonnistui!
        at fi.vm.sade.valintalaskenta.tulos.service.impl.rest.ValintatietoServiceImpl.haeValintatiedot(ValintatietoServiceImpl.java:113)
        at fi.vm.sade.sijoittelu.laskenta.resource.SijoitteluResource.toteutaSijoittelu(SijoitteluResource.java:260)
        at fi.vm.sade.sijoittelu.laskenta.resource.SijoitteluResource.lambda$sijoittele$0(SijoitteluResource.java:89)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NullPointerException
        at fi.vm.sade.valintalaskenta.tulos.dao.impl.ValinnanvaiheDAOImpl.populateJonosijat(ValinnanvaiheDAOImpl.java:120)
        at fi.vm.sade.valintalaskenta.tulos.dao.impl.ValinnanvaiheDAOImpl.migrate(ValinnanvaiheDAOImpl.java:135)
        at fi.vm.sade.valintalaskenta.tulos.dao.impl.ValinnanvaiheDAOImpl.lambda$migrate$4(ValinnanvaiheDAOImpl.java:159)