### PR TITLE
OY-5271 Tietoturvapäivitykset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Deploy jar library
-        if: github.ref == 'refs/heads/master'
+        #if: github.ref == 'refs/heads/master'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Deploy jar library
-        #if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.9</version>
     </parent>
 
     <groupId>fi.vm.sade.sijoittelu</groupId>
@@ -33,7 +33,7 @@
   <properties>
     <jackson.version>2.18.2</jackson.version>
     <spring.security.version>6.4.2</spring.security.version>
-    <valintalaskenta.version>7.0.0-SNAPSHOT</valintalaskenta.version>
+    <valintalaskenta.version>7.1.1-SNAPSHOT</valintalaskenta.version>
     <valintaperusteet-api.version>7.0-SNAPSHOT</valintaperusteet-api.version>
   </properties>
 
@@ -213,6 +213,11 @@
         <version>2.36.0</version>
       </dependency>
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.3.1-jre</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.12.0</version>
@@ -269,28 +274,8 @@
       </dependency>
       <dependency>
         <groupId>ch.qos.logback.access</groupId>
-        <artifactId>tomcat</artifactId>
-        <version>2.0.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-servlet-api</artifactId>
-        <version>10.1.34</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-coyote</artifactId>
-        <version>10.1.34</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-catalina</artifactId>
-        <version>10.1.34</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
-        <version>10.1.34</version>
+        <artifactId>logback-access-tomcat</artifactId>
+        <version>2.0.6</version>
       </dependency>
 
       <!-- Lukitaan transitiivisten riippuvuuksien versioita jotta enforcer-plugin ei valita -->

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,11 @@
         <version>33.3.1-jre</version>
       </dependency>
       <dependency>
+          <groupId>com.hubspot.immutables</groupId>
+          <artifactId>immutables-exceptions</artifactId>
+          <version>1.9</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.12.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>fi.vm.sade.sijoittelu</groupId>
     <artifactId>sijoittelu</artifactId>
     <packaging>pom</packaging>
-    <version>10.0.1-SNAPSHOT</version>
+    <version>10.0.2-SNAPSHOT</version>
     <name>Sijoittelu</name>
     <modules>
         <module>sijoittelu-tulos-api</module>
@@ -33,8 +33,8 @@
   <properties>
     <jackson.version>2.18.2</jackson.version>
     <spring.security.version>6.4.2</spring.security.version>
-    <valintalaskenta.version>7.1.1-SNAPSHOT</valintalaskenta.version>
-    <valintaperusteet-api.version>7.1.1-SNAPSHOT</valintaperusteet-api.version>
+    <valintalaskenta.version>7.1.2-SNAPSHOT</valintalaskenta.version>
+    <valintaperusteet-api.version>7.2.2-MERGE-SNAPSHOT</valintaperusteet-api.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>fi.vm.sade.sijoittelu</groupId>
     <artifactId>sijoittelu</artifactId>
     <packaging>pom</packaging>
-    <version>10.0.0-SNAPSHOT</version>
+    <version>10.0.1-SNAPSHOT</version>
     <name>Sijoittelu</name>
     <modules>
         <module>sijoittelu-tulos-api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
       <dependency>
         <groupId>fi.vm.sade</groupId>
         <artifactId>valinta-tulos-valintarekisteri-db</artifactId>
-        <version>8.3.1-SNAPSHOT</version>
+        <version>8.3.2-SNAPSHOT</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.9</version>
+        <version>3.4.10</version>
     </parent>
 
     <groupId>fi.vm.sade.sijoittelu</groupId>
@@ -113,7 +113,7 @@
       <dependency>
         <groupId>fi.vm.sade</groupId>
         <artifactId>valinta-tulos-valintarekisteri-db</artifactId>
-        <version>8.3.0-SNAPSHOT</version>
+        <version>8.3.1-SNAPSHOT</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -371,12 +371,6 @@
         <artifactId>scala-compiler</artifactId>
         <version>2.11.12</version>
       </dependency>
-      <dependency>
-        <groupId>com.hubspot.jinjava</groupId>
-        <artifactId>jinjava</artifactId>
-        <version>2.5.4</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <jackson.version>2.18.2</jackson.version>
     <spring.security.version>6.4.2</spring.security.version>
     <valintalaskenta.version>7.1.1-SNAPSHOT</valintalaskenta.version>
-    <valintaperusteet-api.version>7.0-SNAPSHOT</valintaperusteet-api.version>
+    <valintaperusteet-api.version>7.1.1-SNAPSHOT</valintaperusteet-api.version>
   </properties>
 
   <dependencyManagement>

--- a/sijoittelu-algoritmi-batch/pom.xml
+++ b/sijoittelu-algoritmi-batch/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <artifactId>sijoittelu</artifactId>
         <groupId>fi.vm.sade.sijoittelu</groupId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>10.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sijoittelu-algoritmi-batch</artifactId>
     <name>Sijoittelu :: Algoritmi :: Batch</name>
     <packaging>jar</packaging>
-    <version>10.0.0-SNAPSHOT</version>
+    <version>10.0.1-SNAPSHOT</version>
 
     <dependencies>
 

--- a/sijoittelu-algoritmi-batch/pom.xml
+++ b/sijoittelu-algoritmi-batch/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <artifactId>sijoittelu</artifactId>
         <groupId>fi.vm.sade.sijoittelu</groupId>
-        <version>10.0.1-SNAPSHOT</version>
+        <version>10.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>sijoittelu-algoritmi-batch</artifactId>
     <name>Sijoittelu :: Algoritmi :: Batch</name>
     <packaging>jar</packaging>
-    <version>10.0.1-SNAPSHOT</version>
+    <version>10.0.2-SNAPSHOT</version>
 
     <dependencies>
 

--- a/sijoittelu-algoritmi-domain/pom.xml
+++ b/sijoittelu-algoritmi-domain/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <artifactId>sijoittelu</artifactId>
         <groupId>fi.vm.sade.sijoittelu</groupId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>10.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sijoittelu-algoritmi-domain</artifactId>
     <name>Sijoittelu :: Algoritmi :: Domain</name>
     <packaging>jar</packaging>
-    <version>10.0.0-SNAPSHOT</version>
+    <version>10.0.1-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/sijoittelu-algoritmi-domain/pom.xml
+++ b/sijoittelu-algoritmi-domain/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <artifactId>sijoittelu</artifactId>
         <groupId>fi.vm.sade.sijoittelu</groupId>
-        <version>10.0.1-SNAPSHOT</version>
+        <version>10.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>sijoittelu-algoritmi-domain</artifactId>
     <name>Sijoittelu :: Algoritmi :: Domain</name>
     <packaging>jar</packaging>
-    <version>10.0.1-SNAPSHOT</version>
+    <version>10.0.2-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/sijoittelu-service/pom.xml
+++ b/sijoittelu-service/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>fi.vm.sade.sijoittelu</groupId>
 		<artifactId>sijoittelu</artifactId>
-		<version>10.0.1-SNAPSHOT</version>
+		<version>10.0.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>sijoittelu-service</artifactId>
 	<name>Sijoittelu :: Service :: API</name>
 	<packaging>jar</packaging>
-	<version>10.0.1-SNAPSHOT</version>
+	<version>10.0.2-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>

--- a/sijoittelu-service/pom.xml
+++ b/sijoittelu-service/pom.xml
@@ -189,7 +189,7 @@
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback.access</groupId>
-			<artifactId>tomcat</artifactId>
+			<artifactId>logback-access-tomcat</artifactId>
 		</dependency>
 
 		<!-- Tests -->

--- a/sijoittelu-service/pom.xml
+++ b/sijoittelu-service/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>fi.vm.sade.sijoittelu</groupId>
 		<artifactId>sijoittelu</artifactId>
-		<version>10.0.0-SNAPSHOT</version>
+		<version>10.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>sijoittelu-service</artifactId>
 	<name>Sijoittelu :: Service :: API</name>
 	<packaging>jar</packaging>
-	<version>10.0.0-SNAPSHOT</version>
+	<version>10.0.1-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>

--- a/sijoittelu-service/src/test/java/fi/vm/sade/sijoittelu/SijoitteluBusinessServiceValintarekisteriTest.java
+++ b/sijoittelu-service/src/test/java/fi/vm/sade/sijoittelu/SijoitteluBusinessServiceValintarekisteriTest.java
@@ -569,7 +569,7 @@ public class SijoitteluBusinessServiceValintarekisteriTest {
         HakukohdeDTO hakukohde = new HakukohdeDTO();
         hakukohde.setOid(uusiHakukohdeOid);
         ValintatietoValinnanvaiheDTO vaihe = new ValintatietoValinnanvaiheDTO(
-            1, "1", hakuOid, "vaihe1", new java.util.Date(), jonot, Collections.emptyList());
+            1, "1", hakuOid, "vaihe1", new java.util.Date(), jonot, Collections.emptyList(), uusiHakukohdeOid);
         hakukohde.setValinnanvaihe(Collections.singletonList(vaihe));
         List<HakukohdeDTO> hakukohdeDtos = new ArrayList<>();
         if (lisaaValintarekisterinHakukohteet) {
@@ -777,14 +777,14 @@ public class SijoitteluBusinessServiceValintarekisteriTest {
         kohde1.setOid(uusiHakukohdeOid);
         ValintatietoValintatapajonoDTO kohde1jono = jonoDTO(uusiHakukohdeOid + ".111111");
         ValintatietoValinnanvaiheDTO kohde1Vaihe = new ValintatietoValinnanvaiheDTO(
-            1, "1", hakuOid, "vaihe1", new java.util.Date(), Collections.singletonList(kohde1jono), Collections.emptyList());
+            1, "1", hakuOid, "vaihe1", new java.util.Date(), Collections.singletonList(kohde1jono), Collections.emptyList(), kohde1.getOid());
         kohde1.setValinnanvaihe(Collections.singletonList(kohde1Vaihe));
 
         HakukohdeDTO kohde2 = new HakukohdeDTO();
         kohde2.setOid("toinenUusiHakukohde");
         ValintatietoValintatapajonoDTO kohde2Jono = jonoDTO("toinenUusiHakukohde" + ".111111");
         ValintatietoValinnanvaiheDTO kohde2Vaihe = new ValintatietoValinnanvaiheDTO(
-            1, "1", hakuOid, "vaihe1", new java.util.Date(), Collections.singletonList(kohde2Jono), Collections.emptyList());
+            1, "1", hakuOid, "vaihe1", new java.util.Date(), Collections.singletonList(kohde2Jono), Collections.emptyList(), kohde2.getOid());
         kohde2.setValinnanvaihe(Collections.singletonList(kohde2Vaihe));
 
         hakuDto.setHakukohteet(Arrays.asList(kohde1, kohde2));

--- a/sijoittelu-service/src/test/java/fi/vm/sade/sijoittelu/SijoitteluTilatJaKuvauksetTest.java
+++ b/sijoittelu-service/src/test/java/fi/vm/sade/sijoittelu/SijoitteluTilatJaKuvauksetTest.java
@@ -188,7 +188,7 @@ public class SijoitteluTilatJaKuvauksetTest {
 
         HakukohdeDTO hakukohde = new HakukohdeDTO();
         hakukohde.setOid(hakukohdeOid);
-        ValintatietoValinnanvaiheDTO vaihe = new ValintatietoValinnanvaiheDTO(1, "1", hakuOid, "vaihe1", new java.util.Date(), jonot, Collections.emptyList());
+        ValintatietoValinnanvaiheDTO vaihe = new ValintatietoValinnanvaiheDTO(1, "1", hakuOid, "vaihe1", new java.util.Date(), jonot, Collections.emptyList(), hakukohdeOid);
         hakukohde.setValinnanvaihe(Arrays.asList(vaihe));
         haku.setHakukohteet(Arrays.asList(hakukohde));
         return haku;

--- a/sijoittelu-tulos-api/pom.xml
+++ b/sijoittelu-tulos-api/pom.xml
@@ -5,12 +5,12 @@
 	<artifactId>sijoittelu-tulos-api</artifactId>
 	<name>Sijoittelu :: Tulos :: API</name>
 	<packaging>jar</packaging>
-	<version>10.0.0-SNAPSHOT</version>
+	<version>10.0.1-SNAPSHOT</version>
 
 	<parent>
 		<groupId>fi.vm.sade.sijoittelu</groupId>
 		<artifactId>sijoittelu</artifactId>
-		<version>10.0.0-SNAPSHOT</version>
+		<version>10.0.1-SNAPSHOT</version>
 	</parent>
 
 

--- a/sijoittelu-tulos-api/pom.xml
+++ b/sijoittelu-tulos-api/pom.xml
@@ -5,12 +5,12 @@
 	<artifactId>sijoittelu-tulos-api</artifactId>
 	<name>Sijoittelu :: Tulos :: API</name>
 	<packaging>jar</packaging>
-	<version>10.0.1-SNAPSHOT</version>
+	<version>10.0.2-SNAPSHOT</version>
 
 	<parent>
 		<groupId>fi.vm.sade.sijoittelu</groupId>
 		<artifactId>sijoittelu</artifactId>
-		<version>10.0.1-SNAPSHOT</version>
+		<version>10.0.2-SNAPSHOT</version>
 	</parent>
 
 

--- a/sijoittelu-tulos-service/pom.xml
+++ b/sijoittelu-tulos-service/pom.xml
@@ -7,12 +7,12 @@
     <artifactId>sijoittelu-tulos-service</artifactId>
     <packaging>jar</packaging>
     <name>Sijoittelu :: Tulos :: Service</name>
-    <version>10.0.0-SNAPSHOT</version>
+    <version>10.0.1-SNAPSHOT</version>
 
     <parent>
         <groupId>fi.vm.sade.sijoittelu</groupId>
         <artifactId>sijoittelu</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>10.0.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/sijoittelu-tulos-service/pom.xml
+++ b/sijoittelu-tulos-service/pom.xml
@@ -7,12 +7,12 @@
     <artifactId>sijoittelu-tulos-service</artifactId>
     <packaging>jar</packaging>
     <name>Sijoittelu :: Tulos :: Service</name>
-    <version>10.0.1-SNAPSHOT</version>
+    <version>10.0.2-SNAPSHOT</version>
 
     <parent>
         <groupId>fi.vm.sade.sijoittelu</groupId>
         <artifactId>sijoittelu</artifactId>
-        <version>10.0.1-SNAPSHOT</version>
+        <version>10.0.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Spring Bootin patch-version päivitys ratkaisi monta ongelmaa jo itsessään.

Logbackin access-logien tomcat-paketti on vaihtanut nimeä. Paketti on siis sama, sille vain tehtiin patch-version päivitys. Spring Bootin ja tämän yhdistelmä päivitti kaikki tomcatin riippuvuudet, joten alipaketit pystyi poistamaan dependency managementista.

Valintalaskenta piti päivittää, jotta päästään eroon valintaperusteista periytyvästä QueryDSL-ongelmasta. Viime päivityksen jälkeen ValintatietoValinnanvaiheDTO:n konstruktori on muuttunut, joten joitakin testejä joutui muuttamaan.

Guavan versio on tullut aiemmin Spring Bootin managed dependencyistä, mutta se poistettiin versiossa 3.4.3. Juuri-POMiin lisätään versio Guavalle, sama versio mikä tuli aiemmin Spring Bootilta.